### PR TITLE
Update runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,5 +57,5 @@ outputs:
     changelog_message:
         description: 'Generated changelog entry'
 runs:
-    using: 'node20'
+    using: 'node24'
     main: 'index.js'


### PR DESCRIPTION
## Summary
- Update `action.yml` runtime from `node20` to `node24` to avoid deprecation when GitHub Actions forces Node.js 24 as default on June 2, 2026.

## Changes
- `action.yml`: `using: 'node20'` → `using: 'node24'`

After merging, create tag `1.4.9` so `viz_ios` workflows can reference it.